### PR TITLE
Queue both send and receive

### DIFF
--- a/lib/consumer.d.ts
+++ b/lib/consumer.d.ts
@@ -6,6 +6,7 @@ export declare type SourceConfig<T> = {
     topic: string;
     receive: (action: Operation<T>) => Promise<void>;
     ssl?: SSLConfig;
+    concurrency?: number;
 };
 export declare type KafkaMessage = {
     message: {
@@ -13,4 +14,4 @@ export declare type KafkaMessage = {
     };
     offset?: number;
 };
-export declare const createReceive: <T>({url, name, topic, receive, ssl}: SourceConfig<T>) => Promise<any>;
+export declare const createReceive: <T>({url, name, topic, receive, ssl, concurrency}: SourceConfig<T>) => Promise<any>;

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -2,6 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const no_kafka_1 = require("no-kafka");
 const uuid = require("node-uuid");
+const PQueue = require("p-queue");
 const index_1 = require("./index");
 const Logger = require("./logger");
 const OFFSET_COMMIT_INTERVAL = 1000;
@@ -19,7 +20,7 @@ const parseMessage = ({ offset, message: { value } }) => {
     }
     return { message, offset };
 };
-exports.createReceive = async ({ url, name, topic, receive, ssl = {} }) => {
+exports.createReceive = async ({ url, name, topic, receive, ssl = {}, concurrency = 8 }) => {
     if (!(typeof url === 'string' && typeof name === 'string' && typeof topic === 'string')) {
         throw new Error('createSource should be called with a config containing a url, name, topic and receiveFn.');
     }
@@ -33,12 +34,17 @@ exports.createReceive = async ({ url, name, topic, receive, ssl = {} }) => {
             logFunction: Logger.log
         }
     });
+    console.log('Queueing receive with concurrency:', concurrency);
+    const queue = new PQueue({
+        concurrency
+    });
     const dataHandler = async (messageSet, topic, partition) => {
         const messagesSent = Promise.all(messageSet.map(parseMessage).map(({ message, offset }) => {
             if (!index_1.isOperation(message))
                 throw new Error(`Non-action encountered: ${message}`);
             const progress = { topic, partition, offset };
-            return Promise.resolve(receive(message)).then(() => {
+            return queue.add(async () => {
+                await receive(message);
                 return consumer.commitOffset(progress);
             });
         }));

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,6 +30,7 @@ async function memux({ name, url, input, output, receive, concurrency, ssl }) {
             url,
             topic: input,
             receive,
+            concurrency: concurrency,
             ssl
         });
     if (output != null)

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -15,6 +15,7 @@ exports.createSend = async ({ url, name, topic, concurrency = 8, ssl = {} }) => 
             logFunction: Logger.log
         }
     });
+    console.log('Queueing send with concurrency:', concurrency);
     const queue = new PQueue({
         concurrency
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ async function memux<T>({ name, url, input, output, receive, concurrency, ssl }:
     url,
     topic: input,
     receive,
+    concurrency: concurrency,
     ssl
   });
 

--- a/src/producer.ts
+++ b/src/producer.ts
@@ -27,6 +27,7 @@ export const createSend = async <T>({ url, name, topic, concurrency = 8, ssl = {
     }
   });
 
+  console.log('Queueing send with concurrency:', concurrency);
   const queue = new PQueue({
     concurrency
   });


### PR DESCRIPTION
This PR adds queuing to the consumer to ensure the rate at which messages are processed can be controlled the consumer and producer end. A possible addition to this could be separate control over the concurrency between the consumer and producer, but for now this is not really needed. 