### PR TITLE
Fix errors being swallowed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
         environment:
           NODE_ENV: test
       - image: wurstmeister/zookeeper:latest
-      - image: wurstmeister/kafka:latest
+      - image: wurstmeister/kafka:1.0.0
         environment:
           KAFKA_AUTO_CREATE_TOPICS_ENABLE: false
           KAFKA_ZOOKEEPER_CONNECT: localhost:2181

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -39,7 +39,7 @@ exports.createReceive = async ({ url, name, topic, receive, ssl = {}, concurrenc
         concurrency
     });
     const dataHandler = async (messageSet, topic, partition) => {
-        const messagesSent = Promise.all(messageSet.map(parseMessage).map(({ message, offset }) => {
+        return await Promise.all(messageSet.map(parseMessage).map(({ message, offset }) => {
             if (!index_1.isOperation(message))
                 throw new Error(`Non-action encountered: ${message}`);
             const progress = { topic, partition, offset };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "@reactivex/rxjs": "^5.4.2",
-    "@types/node": "^8.0.10",
+    "@types/node": "^9.4.0",
     "@types/node-uuid": "^0.0.28",
     "no-kafka": "^3.2.0",
     "node-uuid": "^1.4.8",

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -63,7 +63,7 @@ export const createReceive = async <T>({ url, name, topic, receive, ssl = {}, co
   });
 
   const dataHandler = async (messageSet, topic, partition) => {
-    const messagesSent = Promise.all(messageSet.map(parseMessage).map(({ message, offset}) => {
+    return await Promise.all(messageSet.map(parseMessage).map(({ message, offset}) => {
       if (!isOperation<T>(message)) throw new Error(`Non-action encountered: ${message}`);
       const progress = { topic, partition, offset };
       return queue.add(async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,9 +64,13 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@^8.0.10":
+"@types/node@*":
   version "8.0.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.14.tgz#4a19dc6bb61d16c01cbadc7b30ac23518fff176b"
+
+"@types/node@^9.4.0":
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.0.tgz#b85a0bcf1e1cc84eb4901b7e96966aedc6f078d1"
 
 abbrev@1:
   version "1.1.0"
@@ -509,6 +513,10 @@ babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
 babel-plugin-syntax-trailing-function-commas@^6.20.0, babel-plugin-syntax-trailing-function-commas@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
@@ -697,6 +705,13 @@ babel-plugin-transform-exponentiation-operator@^6.8.0:
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-object-rest-spread@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
+
 babel-plugin-transform-regenerator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz#b8da305ad43c3c99b4848e4fe4037b770d23c418"
@@ -770,6 +785,13 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0:
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
+
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
 
 babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0:
   version "6.25.0"
@@ -2960,6 +2982,10 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
 regenerator-transform@0.9.11:
   version "0.9.11"


### PR DESCRIPTION
This PR adds an `await` statement to fix error propagation from inside the receive function. There was also a regression in the latest build of `wurstmeister/kafka`, but `1.0.0` is stable.